### PR TITLE
replace findAndSetUNElementLength

### DIFF
--- a/src/readDicomElementExplicit.js
+++ b/src/readDicomElementExplicit.js
@@ -1,6 +1,6 @@
 import findEndOfEncapsulatedElement from './findEndOfEncapsulatedPixelData.js';
 import findAndSetUNElementLength from './findAndSetUNElementLength.js';
-import readSequenceItemsImplicit from './readSequenceItemsImplicit.js';
+import readSequenceItemsImplicit  from './readSequenceElementImplicit.js';
 import readTag from './readTag.js';
 import readSequenceItemsExplicit from './readSequenceElementExplicit.js';
 

--- a/src/readDicomElementExplicit.js
+++ b/src/readDicomElementExplicit.js
@@ -2,6 +2,7 @@ import findEndOfEncapsulatedElement from './findEndOfEncapsulatedPixelData.js';
 import findAndSetUNElementLength from './findAndSetUNElementLength.js';
 import readSequenceItemsImplicit  from './readSequenceElementImplicit.js';
 import readTag from './readTag.js';
+import findItemDelimitationItemAndSetElementLength from './findItemDelimitationItem.js';
 import readSequenceItemsExplicit from './readSequenceElementExplicit.js';
 
 /**

--- a/src/readDicomElementExplicit.js
+++ b/src/readDicomElementExplicit.js
@@ -1,6 +1,6 @@
 import findEndOfEncapsulatedElement from './findEndOfEncapsulatedPixelData.js';
 import findAndSetUNElementLength from './findAndSetUNElementLength.js';
-import findItemDelimitationItemAndSetElementLength from './findItemDelimitationItem.js';
+import readSequenceItemsImplicit from './readSequenceItemsImplicit.js';
 import readTag from './readTag.js';
 import readSequenceItemsExplicit from './readSequenceElementExplicit.js';
 
@@ -65,7 +65,7 @@ export default function readDicomElementExplicit (byteStream, warnings, untilTag
 
       return element;
     } else if (element.vr === 'UN') {
-      findAndSetUNElementLength(byteStream, element);
+      readSequenceItemsImplicit(byteStream, element);
 
       return element;
     }


### PR DESCRIPTION


[undefined_length_un_vr.zip](https://github.com/chafey/dicomParser/files/1284351/undefined_length_un_vr.zip)

If elements with UN contain nested sequences the calculation of the element length with 'findAndSetUNElementLength' is wrong because the first found sequence delimitter is not the closing one of the sequence.
According to the DICOM standard sequences with undefined length sould be interpreted as implicit so we can use 'readSequenceItemsImplicit' instead.
(http://dicom.nema.org/medical/Dicom/current/output/chtml/part05/sect_6.2.2.html)
Maybe this solves the bug https://github.com/chafey/dicomParser/issues/62, but i have no images for testing.

I have attached a dicomfile that causes the Problem (https://sourceforge.net/projects/gdcm/files/gdcmData/)