### PR TITLE
Fix #75 where parseTM did not properly calculate fractional seconds.

### DIFF
--- a/src/util/parseTM.js
+++ b/src/util/parseTM.js
@@ -5,14 +5,15 @@
  * @returns {*} javascript object with properties for hours, minutes, seconds and fractionalSeconds or undefined if no element or data.  Missing fields are set to undefined
  */
 export default function parseTM (time, validate) {
-  if (time.length >= 2) // must at least have HH
-  {
+  if (time.length >= 2) { // must at least have HH
     // 0123456789
     // HHMMSS.FFFFFF
-    var hh = parseInt(time.substring(0, 2), 10);
-    var mm = time.length >= 4 ? parseInt(time.substring(2, 4), 10) : undefined;
-    var ss = time.length >= 6 ? parseInt(time.substring(4, 6), 10) : undefined;
-    var ffffff = time.length >= 8 ? parseInt(time.substring(7, 13), 10) : undefined;
+    const hh = parseInt(time.substring(0, 2), 10);
+    const mm = time.length >= 4 ? parseInt(time.substring(2, 4), 10) : undefined;
+    const ss = time.length >= 6 ? parseInt(time.substring(4, 6), 10) : undefined;
+
+    const fractionalStr = time.length >= 8 ? time.substring(7, 13) : undefined;
+    const ffffff = fractionalStr ? (parseInt(fractionalStr, 10) * Math.pow(10, 6 - fractionalStr.length)) : undefined;
 
     if (validate) {
       if ((isNaN(hh)) ||

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -167,7 +167,7 @@ describe('util', () => {
 
     describe('when parsing a partial fractional TM', () => {
 
-      it('should return the expected value', () => {
+      it('should return the expected value for no zeros', () => {
         // Arrange
         const tmString = '081236.5';
 
@@ -178,7 +178,21 @@ describe('util', () => {
         expect(val.hours).to.equal(8);
         expect(val.minutes).to.equal(12);
         expect(val.seconds).to.equal(36);
-        expect(val.fractionalSeconds).to.equal(5);
+        expect(val.fractionalSeconds).to.equal(500000);
+      });
+
+      it('should return the expected value for leading and following zeros', () => {
+        // Arrange
+        const tmString = '081236.00500';
+
+        // Act
+        const val = util.parseTM(tmString);
+
+        // Assert
+        expect(val.hours).to.equal(8);
+        expect(val.minutes).to.equal(12);
+        expect(val.seconds).to.equal(36);
+        expect(val.fractionalSeconds).to.equal(5000);
       });
 
     });


### PR DESCRIPTION
Did a jsperf and on my machine this code is 4 times faster than the other way to fix it with padEnd.