### PR TITLE
Set default to 0 for undefined time units minutes, seconds and millisec

### DIFF
--- a/src/util/parseTM.js
+++ b/src/util/parseTM.js
@@ -10,9 +10,9 @@ export default function parseTM (time, validate) {
     // 0123456789
     // HHMMSS.FFFFFF
     var hh = parseInt(time.substring(0, 2), 10);
-    var mm = time.length >= 4 ? parseInt(time.substring(2, 4), 10) : undefined;
-    var ss = time.length >= 6 ? parseInt(time.substring(4, 6), 10) : undefined;
-    var ffffff = time.length >= 8 ? parseInt(time.substring(7, 13), 10) : undefined;
+    var mm = time.length >= 4 ? parseInt(time.substring(2, 4), 10) : 0;
+    var ss = time.length >= 6 ? parseInt(time.substring(4, 6), 10) : 0;
+    var ffffff = time.length >= 8 ? parseInt(time.substring(7, 13), 10) : 0;
 
     if (validate) {
       if ((isNaN(hh)) ||

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -150,17 +150,17 @@ describe('util', () => {
 
       it('should return the right minutes', () => {
         // Assert
-        expect(val.minutes).to.be.undefined;
+        expect(val.minutes).to.equal(0);
       });
 
       it('should return the right seconds', () => {
         // Assert
-        expect(val.seconds).to.be.undefined;
+        expect(val.seconds).to.equal(0);
       });
 
       it('should return the right fractionalSeconds', () => {
         // Assert
-        expect(val.fractionalSeconds).to.be.undefined;
+        expect(val.fractionalSeconds).to.equal(0);
       });
 
     });


### PR DESCRIPTION
We can set 0 for undefined time units based on TM definition in DICOM standard http://dicom.nema.org/Dicom/2013/output/chtml/part05/sect_6.2.html.

This PR intends to solve [cornerstone issue #245]( https://github.com/cornerstonejs/cornerstone/issues/245)