### PR TITLE
Fix bug where peeking to determine whether a field is an SQ would be …

### DIFF
--- a/src/readDicomElementImplicit.js
+++ b/src/readDicomElementImplicit.js
@@ -9,8 +9,11 @@ import { isPrivateTag } from './util/util.js';
 
 const isSequence = (element, byteStream, vrCallback) => {
   // if a data dictionary callback was provided, use that to verify that the element is a sequence.
-  if (typeof vrCallback !== 'undefined') {
-    return (vrCallback(element.tag) === 'SQ');
+  if (vrCallback !== undefined) {
+    const callbackValue = vrCallback(element.tag);
+    if (callbackValue !== undefined) {
+      return (callbackValue === 'SQ');
+    }
   }
 
   if ((byteStream.position + 4) <= byteStream.byteArray.length) {

--- a/test/parseDicomDataSet_test.js
+++ b/test/parseDicomDataSet_test.js
@@ -90,7 +90,7 @@ describe('parseDicomDataSet', () => {
         0xfe, 0xff, 0x00, 0xe0, 0x0A, 0x00, 0x00, 0x00,
       ];
       const callback = (tag) => {
-        return undefined; // nothing should be interpreted as an SQ
+        return (tag === 'x7fe00010') ? 'OW' : undefined;
       };
       const byteArray = convertToByteArray(bytes);
       const byteStream = new ByteStream(littleEndianByteArrayParser, byteArray);

--- a/test/readSequenceItemsImplicit_test.js
+++ b/test/readSequenceItemsImplicit_test.js
@@ -28,7 +28,7 @@ describe('readSequenceItemsImplicit', () => {
                  0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00,
     ];
     const callback = (tag) => {
-      return undefined; // nothing should be interpreted as an SQ
+      return (tag === 'x7fe00010') ? 'OW' : undefined;
     };
     const byteStream = new ByteStream(littleEndianByteArrayParser, convertToByteArray(bytes));
     const element = { length: 0xFFFFFFFF };
@@ -95,7 +95,7 @@ describe('readSequenceItemsImplicit', () => {
                  0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00,
     ];
     const callback = (tag) => {
-      return undefined; // nothing should be interpreted as an SQ
+      return (tag === 'x7fe00010') ? 'OW' : undefined;
     };
     const byteStream = new ByteStream(littleEndianByteArrayParser, convertToByteArray(bytes));
     const element = { length: 0xFFFFFFFF };
@@ -128,7 +128,7 @@ describe('readSequenceItemsImplicit', () => {
                  0xfe, 0xff, 0x00, 0xe0, 0x0A, 0x00, 0x00, 0x00,
     ];
     const callback = (tag) => {
-      return undefined; // nothing should be interpreted as an SQ
+      return (tag === 'x7fe00010') ? 'OW' : undefined;
     };
     const byteStream = new ByteStream(littleEndianByteArrayParser, convertToByteArray(bytes));
     const element = {dataOffset: 0, length: 24};


### PR DESCRIPTION
…skipped if the vrCallback returned undefined, meaning it could not determine the VR.