### PR TITLE
Fix issue #114 - Fail to find the image element in a DICOM file with private Sequence tags

### DIFF
--- a/src/readDicomElementImplicit.js
+++ b/src/readDicomElementImplicit.js
@@ -1,6 +1,7 @@
 import findItemDelimitationItemAndSetElementLength from './findItemDelimitationItem.js';
 import readSequenceItemsImplicit from './readSequenceElementImplicit.js';
 import readTag from './readTag.js';
+import { isPrivateTag } from './util/util.js';
 
 /**
  * Internal helper functions for for parsing DICOM elements
@@ -48,7 +49,7 @@ export default function readDicomElementImplicit (byteStream, untilTag, vrCallba
     return element;
   }
 
-  if (isSequence(element, byteStream, vrCallback)) {
+  if (isSequence(element, byteStream, vrCallback) && !isPrivateTag(element.tag)) {
     // parse the sequence
     readSequenceItemsImplicit(byteStream, element);
 


### PR DESCRIPTION
The PR fix and prevent the behavior of the parser "trying to detect and parse private sequences as they not necessarily follow the DICOM standard" causing the parser state to be corrupt.