### PR TITLE
GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Live Examples
 
 The best way to see the power of this library is to actually see it in use.  A number of live examples are
 included that are not only useful but also show how to use dicomParser.
-[Click here for a list of all live examples](https://rawgithub.com/cornerstonejs/dicomParser/master/examples/index.html)
-Make sure you try out the [DICOM Dump with Data Dictionary](https://rawgit.com/cornerstonejs/dicomParser/master/examples/dumpWithDataDictionary/index.html)
+[Click here for a list of all live examples](https://cornerstonejs.github.io/dicomParser/examples/index.html)
+Make sure you try out the [DICOM Dump with Data Dictionary](https://cornerstonejs.github.io/dicomParser/examples/dumpWithDataDictionary/index.html)
 which is a very useful tool and excellent example of most features.
 
 Community
@@ -72,7 +72,7 @@ catch(ex)
 }
 ```
 
-[See the live examples for more in depth usage of the library](https://rawgithub.com/cornerstonejs/dicomParser/master/examples/index.html)
+[See the live examples for more in depth usage of the library](https://cornerstonejs.github.io/dicomParser/examples/index.html)
 
 Note that actually displaying DICOM images is quite complex due to the variety of pixel formats and compression
 algorithms that DICOM supports.  If you are interested in displaying images, please take a look at the

--- a/examples/index.html
+++ b/examples/index.html
@@ -42,7 +42,7 @@
 
     <br>
 
-    <a href="https://rawgithub.com/cornerstonejs/dicomParser/master/examples/index.html">Click here
+    <a href="https://cornerstonejs.github.io/dicomParser/examples/index.html">Click here
         to view this page live on github</a>
 
 


### PR DESCRIPTION
Rawgit is about to go away (see front page [here](https://rawgit.com/)) so they recommend hosting your docs on GitHub pages. In order to keep the live examples from being suddenly inaccessible, I've updated the URLs to work with GHPages (full disclosure: I guessed on the URLs, but I think they should be right).  Just need to turn on GHPages for the repo (I recommend using master as the source branch and force https), then accept this PR and it should be good to go. As a bonus, GHPages will provide a themed README at [https://cornerstonejs.github.io/dicomParser](https://cornerstonejs.github.io/dicomParser) once you enable it.