### PR TITLE
Updated TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ declare module 'dicom-parser' {
     position: number;
     warnings: string[];
  
-    new (byteArrayParser: ByteArrayParser, byteArray: ByteArray, position: number);
+    new (byteArrayParser: ByteArrayParser, byteArray: ByteArray, position: number): ByteStream;
     seek: (offset: number) => void;
     readByteStream: (numBytes: number) => ByteStream;
     readUint16: () => number;


### PR DESCRIPTION
This PR fixes [TypeDoc](https://typedoc.org/) generation for projects with dicomParser dependency.

The following error was occurring:

```console
yarn run v1.22.4
$ typedoc

Using TypeScript 3.9.7 from /project/node_modules/typescript/lib
Error: /project/dicom-parser/index.d.ts(103)
 Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.
error Command failed with exit code 4.
```

Resolved this issue by adding constructor return type to ByteStream.

```console
$ typedoc

Using TypeScript 3.9.7 from /project/node_modules/typescript/lib
Rendering [========================================] 100%

Documentation generated at /project/docs

Done in 8.18s.
```