### PR TITLE
Remove Node browser polyfill libraries from the build (#148)

### DIFF
--- a/config/webpack/webpack-base.js
+++ b/config/webpack/webpack-base.js
@@ -10,6 +10,10 @@ module.exports = {
   entry: {
     dicomParser: './index.js'
   },
+  externals: {
+    'zlib': 'zlib'
+  },
+  node: false,
   target: 'web',
   output: {
     filename: '[name].js',

--- a/src/parseDicom.js
+++ b/src/parseDicom.js
@@ -47,7 +47,7 @@ export default function parseDicom (byteArray, options) {
 
   function getDataSetByteStream (transferSyntax, position) {
     // Detect whether we are inside a browser or Node.js
-    const isNode = (typeof window === 'undefined');
+    const isNode = (Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]');
 
     if (transferSyntax === '1.2.840.10008.1.2.1.99') {
       // if an infalter callback is registered, use it


### PR DESCRIPTION
Minified build is now down to 38KB from 163KB.

Found a deflated example DICOM and dropped it in dumpWithDataDictionary. Also used same DICOM in the nodejs example. Both worked.