### PR TITLE
Fix missing zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Javascript parser for DICOM Part 10 data",
   "main": "dist/dicomParser.min.js",
   "module": "dist/dicomParser.min.js",
+  "browser": {
+    "zlib": false
+  },
   "keywords": [
     "DICOM",
     "medical",

--- a/src/byteStream.js
+++ b/src/byteStream.js
@@ -30,7 +30,8 @@ export default class ByteStream {
       throw 'dicomParser.ByteStream: missing required parameter \'byteArray\'';
     }
     if ((byteArray instanceof Uint8Array) === false &&
-          (byteArray instanceof Buffer) === false) {
+          ((typeof Buffer === 'undefined') ||
+          (byteArray instanceof Buffer) === false)) {
       throw 'dicomParser.ByteStream: parameter byteArray is not of type Uint8Array or Buffer';
     }
     if (position < 0) {


### PR DESCRIPTION
Tell bundlers to ignore zlib when building for browser.

Make sure the check for wrong type doesn't crash on missing Buffer symbol in the browser.

Fix #185 