### PR TITLE
dumpWithDataDictionary example - Fix for SL VR

### DIFF
--- a/examples/dumpWithDataDictionary/index.html
+++ b/examples/dumpWithDataDictionary/index.html
@@ -451,6 +451,7 @@ function dumpDataSet(dataSet, output)
                                     || vr === 'SI'
                                     || vr === 'SQ'
                                     || vr === 'SS'
+                                    || vr === 'SL'
                                     || vr === 'UL'
                                     || vr === 'US'
                             ) {


### PR DESCRIPTION
While dumping WSI datasets with Column Position In Total Image Pixel Matrix (0048,021E) and Row Position In Total Image Pixel Matrix (0048,021F) tags, it was noticed that their values were treated as strings rather than numbers.

Actual
![Actual](https://user-images.githubusercontent.com/484163/141421298-e85808d4-501a-4b57-884d-bd57be631502.png)

Expected
![Expected](https://user-images.githubusercontent.com/484163/141421363-f5ddff67-45b3-4b4d-bf48-02efe486f78a.png)

