### PR TITLE
Add missing TransferSyntaxUID in type ParseDicomOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,7 @@ declare module 'dicom-parser' {
   }
 
   export interface ParseDicomOptions {
+    TransferSyntaxUID?: string;
     untilTag?: string;
     vrCallback?: (tag: string) => void;
     inflater?: (arr: Uint8Array, position: number) => void;


### PR DESCRIPTION
I guess `ParseDicomOptions` should contain key of `TransferSyntaxUID`. 

But now the error will be caused by incorrect type in Typescript if the arg is passed to `parseDicom`