### PR TITLE
Type fix: change interface declaration to class for `ByteStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,13 +95,13 @@ declare module 'dicom-parser' {
     attributeTag: (tag: string) => string;
   }
 
-  export interface ByteStream {
+  export class ByteStream {
     byteArray: ByteArray;
     byteArrayParser: ByteArrayParser;
     position: number;
     warnings: string[];
  
-    new (byteArrayParser: ByteArrayParser, byteArray: ByteArray, position: number): ByteStream;
+    constructor(byteArrayParser: ByteArrayParser, byteArray: ByteArray, position: number): ByteStream;
     seek: (offset: number) => void;
     readByteStream: (numBytes: number) => ByteStream;
     readUint16: () => number;


### PR DESCRIPTION
Fixes #187 

This fixe TypeScript error "'ByteStream' only refers to a type, but is being used as a value here. ts(2693)"  when constructing a ByteStream in consuming code like:

```typescript
import { ByteStream, littleEndianByteArrayParser } from "dicom-parser";

const byteStream = new ByteStream(
  littleEndianByteArrayParser,
  new Uint8Array(0),
  0
);
```

Personally tested again ts `4.7.3`.