### PR TITLE
Roll semantic-release down to the most recent version that works with…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run:
           name: Publish package
-          command: npx semantic-release
+          command: npx semantic-release@19.0.5
+
 
 workflows:
   version: 2


### PR DESCRIPTION
… Node.js 16, otherwise we trigger a cascade of dependency updates.